### PR TITLE
Update debug.core and debug.ui to Java 17

### DIFF
--- a/plugins/org.eclipse.m2m.qvt.oml.debug.core/.classpath
+++ b/plugins/org.eclipse.m2m.qvt.oml.debug.core/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.m2m.qvt.oml.debug.core/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/org.eclipse.m2m.qvt.oml.debug.core/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/plugins/org.eclipse.m2m.qvt.oml.debug.core/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.m2m.qvt.oml.debug.core/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.debug.core;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.m2m.qvt.oml;bundle-version="[3.0.0,4.0.0)",
  org.eclipse.m2m.qvt.oml.runtime;bundle-version="[3.0.0,4.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.m2m.qvt.oml.debug.core,
  org.eclipse.m2m.qvt.oml.debug.core.app,

--- a/plugins/org.eclipse.m2m.qvt.oml.debug.ui/.classpath
+++ b/plugins/org.eclipse.m2m.qvt.oml.debug.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.m2m.qvt.oml.debug.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/org.eclipse.m2m.qvt.oml.debug.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/plugins/org.eclipse.m2m.qvt.oml.debug.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.m2m.qvt.oml.debug.ui/META-INF/MANIFEST.MF
@@ -21,5 +21,5 @@ Export-Package: org.eclipse.m2m.internal.qvt.oml.debug.ui;x-friends:="org.eclips
  org.eclipse.m2m.internal.qvt.oml.debug.ui.actions;x-internal:=true,
  org.eclipse.m2m.internal.qvt.oml.debug.ui.views;x-internal:=true
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.m2m.qvt.oml.debug.ui

--- a/releng/org.eclipse.qvto.oomph/setups/qvto.setup
+++ b/releng/org.eclipse.qvto.oomph/setups/qvto.setup
@@ -50,7 +50,7 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="eclipse.target.platform"
-      defaultValue="2024-09"
+      defaultValue="2024-12"
       storageURI="scope://Workspace"/>
   <setupTask
       xsi:type="setup.p2:P2Task">
@@ -97,6 +97,13 @@
             url="https://download.eclipse.org/releases/latest"/>
         <repository
             url="https://download.eclipse.org/tools/orbit/downloads/latest-R"/>
+      </repositoryList>
+      <repositoryList
+          name="2024-12">
+        <repository
+            url="https://download.eclipse.org/releases/2024-12"/>
+        <repository
+            url="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-12"/>
       </repositoryList>
       <repositoryList
           name="2024-09">
@@ -324,17 +331,17 @@
   </setupTask>
   <setupTask
       xsi:type="git:GitCloneTask"
-      id="qvto.git.clone"
-      remoteURI="mmt/org.eclipse.qvto.git">
+      id="qvto.github.clone"
+      remoteURI="eclipse-qvto/org.eclipse.qvto">
     <annotation
         source="http://www.eclipse.org/oomph/setup/InducedChoices">
       <detail
           key="inherit">
-        <value>eclipse.git.gerrit.remoteURIs</value>
+        <value>github.remoteURIs</value>
       </detail>
       <detail
           key="label">
-        <value>QVTo Git or Gerrit Repository</value>
+        <value>QVTo GitHub Repository</value>
       </detail>
       <detail
           key="target">
@@ -360,11 +367,11 @@
     <setupTask
         xsi:type="projects:ProjectsImportTask">
       <sourceLocator
-          rootFolder="${qvto.git.clone.location/plugins}"/>
+          rootFolder="${qvto.github.clone.location/plugins}"/>
       <sourceLocator
-          rootFolder="${qvto.git.clone.location/tests}"/>
+          rootFolder="${qvto.github.clone.location/tests}"/>
       <sourceLocator
-          rootFolder="${qvto.git.clone.location/examples}">
+          rootFolder="${qvto.github.clone.location/examples}">
         <predicate
             xsi:type="predicates:NotPredicate">
           <operand
@@ -498,11 +505,11 @@
     <setupTask
         xsi:type="projects:ProjectsImportTask">
       <sourceLocator
-          rootFolder="${qvto.git.clone.location/doc}"/>
+          rootFolder="${qvto.github.clone.location/doc}"/>
       <sourceLocator
-          rootFolder="${qvto.git.clone.location/features}"/>
+          rootFolder="${qvto.github.clone.location/features}"/>
       <sourceLocator
-          rootFolder="${qvto.git.clone.location/releng}"
+          rootFolder="${qvto.github.clone.location/releng}"
           locateNestedProjects="true"/>
       <description>Releng projects</description>
     </setupTask>

--- a/releng/org.eclipse.qvto.oomph/setups/qvto.setup
+++ b/releng/org.eclipse.qvto.oomph/setups/qvto.setup
@@ -16,8 +16,8 @@
     label="QVTo">
   <setupTask
       xsi:type="jdt:JRETask"
-      version="JavaSE-17"
-      location="${jre.location-17}"/>
+      version="JavaSE-21"
+      location="${jre.location-21}"/>
   <setupTask
       xsi:type="setup:EclipseIniTask"
       option="-Xmx"

--- a/releng/org.eclipse.qvto.releng.tycho/.launches/Build QVTo - Versions.launch
+++ b/releng/org.eclipse.qvto.releng.tycho/.launches/Build QVTo - Versions.launch
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
-<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-<stringAttribute key="M2_GOALS" value="versions:display-plugin-updates"/>
-<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
-<booleanAttribute key="M2_OFFLINE" value="false"/>
-<stringAttribute key="M2_PROFILES" value="nightly"/>
-<listAttribute key="M2_PROPERTIES"/>
-<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
-<booleanAttribute key="M2_SKIP_TESTS" value="false"/>
-<intAttribute key="M2_THREADS" value="1"/>
-<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
-<stringAttribute key="M2_USER_SETTINGS" value=""/>
-<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
-<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
-<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.eclipse.qvto.releng.tycho}"/>
+    <intAttribute key="M2_COLORS" value="0"/>
+    <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+    <stringAttribute key="M2_GOALS" value="versions:display-plugin-updates"/>
+    <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+    <booleanAttribute key="M2_OFFLINE" value="false"/>
+    <stringAttribute key="M2_PROFILES" value="nightly"/>
+    <listAttribute key="M2_PROPERTIES"/>
+    <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+    <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+    <intAttribute key="M2_THREADS" value="1"/>
+    <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+    <stringAttribute key="M2_USER_SETTINGS" value=""/>
+    <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.eclipse.qvto.releng.tycho}"/>
 </launchConfiguration>

--- a/releng/org.eclipse.qvto.releng.tycho/.launches/Build QVTo Distribution - Nightly.launch
+++ b/releng/org.eclipse.qvto.releng.tycho/.launches/Build QVTo Distribution - Nightly.launch
@@ -17,6 +17,6 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.eclipse.qvto.releng.tycho}"/>
 </launchConfiguration>

--- a/releng/org.eclipse.qvto.releng.tycho/.launches/Build QVTo Distribution - Stable.launch
+++ b/releng/org.eclipse.qvto.releng.tycho/.launches/Build QVTo Distribution - Stable.launch
@@ -17,6 +17,6 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.eclipse.qvto.releng.tycho}"/>
 </launchConfiguration>

--- a/releng/org.eclipse.qvto.releng.tycho/pom.xml
+++ b/releng/org.eclipse.qvto.releng.tycho/pom.xml
@@ -47,27 +47,27 @@
     <!-- plugins versions -->
     <!-- use the "Build QVTo - Versions" launch to check for the latest -->
     <eclipse-jarsigner-version>1.3.1</eclipse-jarsigner-version>
-    <exec-maven-version>3.0.0</exec-maven-version>
+    <exec-maven-version>3.5.0</exec-maven-version>
     <findbugs-maven-version>3.0.0</findbugs-maven-version>
     <jacoco-maven-version>0.8.17</jacoco-maven-version>
-    <maven-antrun-version>3.0.0</maven-antrun-version>
-    <maven-assembly-version>3.3.0</maven-assembly-version>
-    <maven-checkstyle-version>3.1.1</maven-checkstyle-version>
-    <maven-clean-version>3.1.0</maven-clean-version>
-    <maven-compiler-version>3.8.1</maven-compiler-version>
-    <maven-deploy-version>3.0.0-M1</maven-deploy-version>
-    <maven-enforcer-version>3.0.0-M3</maven-enforcer-version>
-    <maven-install-version>3.0.0-M1</maven-install-version>
-    <maven-jar-version>3.2.0</maven-jar-version>
-    <maven-javadoc-version>3.2.0</maven-javadoc-version>
-    <maven-jxr-version>3.0.0</maven-jxr-version>
-    <maven-pmd-version>3.13.0</maven-pmd-version>
-    <maven-resources-version>3.2.0</maven-resources-version>
-    <maven-site-version>3.9.1</maven-site-version>
-    <maven-surefire-version>3.0.0-M5</maven-surefire-version>
-    <tycho-version>2.7.5</tycho-version>
+    <maven-antrun-version>3.1.0</maven-antrun-version>
+    <maven-assembly-version>3.7.1</maven-assembly-version>
+    <maven-checkstyle-version>3.6.0</maven-checkstyle-version>
+    <maven-clean-version>3.4.0</maven-clean-version>
+    <maven-compiler-version>3.13.0</maven-compiler-version>
+    <maven-deploy-version>3.1.3</maven-deploy-version>
+    <maven-enforcer-version>3.5.0</maven-enforcer-version>
+    <maven-install-version>3.1.3</maven-install-version>
+    <maven-jar-version>3.4.2</maven-jar-version>
+    <maven-javadoc-version>3.11.2</maven-javadoc-version>
+    <maven-jxr-version>3.6.0</maven-jxr-version>
+    <maven-pmd-version>3.26.0</maven-pmd-version>
+    <maven-resources-version>3.3.1</maven-resources-version>
+    <maven-site-version>4.0.0-M16</maven-site-version>
+    <maven-surefire-version>3.5.2</maven-surefire-version>
+    <tycho-version>4.0.10</tycho-version>
     <tycho-extras-version>${tycho-version}</tycho-extras-version>
-    
+
     <BUILD_ALIAS></BUILD_ALIAS>
     <argLineTail>-Declipse.e4.inject.javax.disabled=true -ea</argLineTail>
   </properties>
@@ -98,7 +98,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>3.6.3</version>
+                  <version>3.9.0</version>
                 </requireMavenVersion>
               </rules>
             </configuration>
@@ -115,7 +115,7 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <resolver>p2</resolver>
+          <!--resolver>p2<resolver-->
           <!-->executionEnvironment>JavaSE-1.8</executionEnvironment-->
           <target>
             <artifact>


### PR DESCRIPTION
Eclipse requires Java 11 since 4.17 (2020-09) and Java 17 since 4.25 (2022-12)